### PR TITLE
Add Receitanet BX diagnostic probe, protocol report, and README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # teste
+
+## Conteúdo
+
+- `RELATORIO_TECNICO_RECEITANET_BX.md`: relatório técnico com a engenharia reversa do protocolo Receitanet BX e análise do erro 5002.
+- `download_receitanetbx.py`: utilitário de diagnóstico semântico para testar combinações de `idSistema`/`idPapel`/campos e rastrear o erro 5002.
+
+## Como testar de forma certeira
+
+### 1) Teste local (sem rede)
+Valida codec de framing + extração de código de erro.
+
+```bash
+python download_receitanetbx.py --self-test
+```
+
+### 2) Teste real com mTLS (matriz semântica)
+Executa varredura de combinações para encontrar tentativas sem `5002`.
+
+```bash
+python download_receitanetbx.py \
+  --pfx /caminho/certificado.pfx \
+  --senha 'SUA_SENHA' \
+  --id-sistemas '100,200,300' \
+  --id-papeis '1,2' \
+  --campos-inicio 'dataInicio,dataIniion' \
+  --data-inicio 01/01/2025 \
+  --data-fim 31/01/2025 \
+  --out-jsonl diagnostico_receitanet/resultados.jsonl \
+  --out-csv diagnostico_receitanet/resultados.csv
+```
+
+Saídas:
+- `diagnostico_receitanet/resultados.jsonl` (log detalhado por tentativa)
+- `diagnostico_receitanet/resultados.csv` (tabela para filtro rápido)

--- a/README.md
+++ b/README.md
@@ -3,19 +3,17 @@
 ## Conteúdo
 
 - `RELATORIO_TECNICO_RECEITANET_BX.md`: relatório técnico com a engenharia reversa do protocolo Receitanet BX e análise do erro 5002.
-- `download_receitanetbx.py`: utilitário de diagnóstico semântico para testar combinações de `idSistema`/`idPapel`/campos e rastrear o erro 5002.
+- `download_receitanetbx.py`: utilitário de diagnóstico semântico/protocolo para testar combinações de `idSistema`/`idPapel`/framing/transporte e rastrear o erro 5002.
 
 ## Como testar de forma certeira
 
 ### 1) Teste local (sem rede)
-Valida codec de framing + extração de código de erro.
 
 ```bash
 python download_receitanetbx.py --self-test
 ```
 
-### 2) Teste real com mTLS (matriz semântica)
-Executa varredura de combinações para encontrar tentativas sem `5002`.
+### 2) Varredura completa (reduzindo `sem_resposta`)
 
 ```bash
 python download_receitanetbx.py \
@@ -24,12 +22,27 @@ python download_receitanetbx.py \
   --id-sistemas '100,200,300' \
   --id-papeis '1,2' \
   --campos-inicio 'dataInicio,dataIniion' \
+  --transport-modes 'tls,tls-no-sni,plain' \
+  --length-endians 'little,big' \
+  --versions '1,2' \
+  --reserved-values '0' \
+  --sni-values 'recnetsped.receita.fazenda.gov.br,' \
   --data-inicio 01/01/2025 \
   --data-fim 31/01/2025 \
   --out-jsonl diagnostico_receitanet/resultados.jsonl \
   --out-csv diagnostico_receitanet/resultados.csv
 ```
 
-Saídas:
-- `diagnostico_receitanet/resultados.jsonl` (log detalhado por tentativa)
-- `diagnostico_receitanet/resultados.csv` (tabela para filtro rápido)
+### 3) Teste com greeting opcional
+
+```bash
+python download_receitanetbx.py \
+  --pfx /caminho/certificado.pfx \
+  --senha 'SUA_SENHA' \
+  --greeting 'text:HELLO\r\n'
+```
+
+## Saídas
+
+- `diagnostico_receitanet/resultados.jsonl`: log completo por tentativa.
+- `diagnostico_receitanet/resultados.csv`: tabela para filtrar padrões (`sem_resposta`, `decode_error`, `5002`, etc.).

--- a/RELATORIO_TECNICO_RECEITANET_BX.md
+++ b/RELATORIO_TECNICO_RECEITANET_BX.md
@@ -1,0 +1,107 @@
+# Relatório Técnico: Engenharia Reversa da API Receitanet BX e Erro 5002
+
+**Objetivo:** Documentar o funcionamento do protocolo proprietário do Receitanet BX, as tentativas de implementação em Python e a persistência do erro de negócio 5002, para orientar futuras tentativas de integração sem repetir caminhos falhos.
+
+## 1. O Protocolo Proprietário (Camada de Transporte)
+
+O Receitanet BX não utiliza REST/JSON nem SOAP padrão. Ele utiliza um protocolo binário customizado sobre TCP/TLS (Porta 3443).
+
+### Estrutura do Pacote
+Todo pacote enviado ou recebido segue este formato de framing:
+
+```text
+[HEADER: 4 bytes] + [PAYLOAD: N bytes]
+```
+
+1. **Header (4 bytes):**
+   - Byte 0: Versão/Tipo (geralmente `0x01` ou `0x02`).
+   - Bytes 1-2: Tamanho do payload descompactado (Big Endian ou Little Endian dependendo da implementação; no Python foi usado `int.to_bytes(2, 'little')` para compatibilidade observada).
+   - Byte 3: Reservado/Flag (geralmente `0x00`).
+2. **Payload (N bytes):**
+   - O conteúdo é comprimido usando **ZLIB**.
+   - Após descompactar, o conteúdo é texto (`ISO-8859-1` ou `UTF-8`).
+
+### Handshake TLS
+- **Host:** `recnetsped.receita.fazenda.gov.br`
+- **Porta:** `3443`
+- **Segurança:** requer TLS 1.2.
+- **Autenticação:** o servidor exige Client Certificate (e-CPF/e-CNPJ) durante o handshake TLS.
+
+---
+
+## 2. Estrutura Lógica da Requisição (Camada de Aplicação)
+
+O payload descompactado segue um formato chave-valor proprietário ou XML simplificado, dependendo da operação.
+
+### Operação: Solicitar Arquivos (Pesquisa)
+Para pesquisar arquivos (SPED, EFD, etc.), o payload identificado na engenharia reversa contém:
+
+- **Identificadores:**
+  - `idSistema`: identificador do sistema (ex.: `100` para SPED Fiscal, mas varia).
+  - `idPapel`: papel do usuário (ex.: `1` para Contribuinte, `2` para Procurador).
+  - `perfil`: tipo de acesso.
+- **Critérios (CRITERIOPESQUISA):**
+  - Campos dinâmicos baseados no tipo de arquivo.
+  - Exemplo comum: data início e fim.
+
+---
+
+## 3. Tentativas Realizadas e Falhas (Erro 5002)
+
+O erro **5002** é retornado pelo servidor da Receita (backend) dentro de um pacote válido. Isso confirma que **o protocolo de rede (TCP/TLS/framing) está correto**, mas o conteúdo da requisição foi rejeitado pela regra de negócio.
+
+### Tentativa A: Payload Padrão de Período
+**Payload enviado:**
+
+```properties
+id=periodoEntrega
+dataInicio=01/01/2025
+dataFim=31/01/2025
+```
+
+**Resultado:** `5002 - Erro no processamento da solicitação.`
+
+**Diagnóstico:** o servidor recebeu, descompactou, leu as chaves, mas rejeitou os valores ou a combinação de chaves.
+
+### Tentativa B: Variação de Nomes de Campo (String Mining)
+Foram encontradas strings suspeitas nos JARs descompilados (`dataIniion` em vez de `dataInicio`).
+
+**Payload enviado:**
+
+```properties
+id=periodoEntrega
+dataIniion=01/01/2025
+# tentativa de typo proposital encontrado no binário
+dataFim=31/01/2025
+```
+
+**Resultado:** `5002` (persistente).
+
+**Diagnóstico:** o nome do campo não parece ser a única causa, ou `dataIniion` é usado apenas em contextos legados específicos.
+
+### Tentativa C: Consulta de Metadados (Sistemas e Papéis)
+Tentativa de consultar a lista de sistemas (`VERSAOSISTEMAS`) para obter os IDs corretos.
+
+**Resultado:** sucesso técnico no envio, mas retorno vazio ou erro genérico dependendo do ambiente.
+
+**Diagnóstico:** a falta dos IDs corretos (`idSistema` e `idPapel` atualizados) é a causa mais provável do 5002 na pesquisa. Se enviado `idSistema=0` ou desatualizado, o backend rejeita.
+
+---
+
+## 4. Conclusão Técnica para Próximas IAs
+
+Se você for tentar corrigir a API Python (`download_receitanetbx.py`), **não** perca tempo com:
+
+1. Handshake TLS (está funcionando).
+2. Compressão ZLIB (está funcionando).
+3. Framing de bytes (está funcionando).
+
+**O problema é semântico (dados do payload):**
+
+- É necessário descobrir os valores exatos de `idSistema` e `idPapel` para o tipo de arquivo solicitado.
+- Esses valores mudam e são baixados dinamicamente pelo cliente oficial na inicialização.
+- **Ação recomendada:** interceptar uma requisição válida do cliente oficial (Wireshark com decriptação ou endpoint de debug) para copiar os IDs vigentes.
+
+## Código de referência
+
+A implementação Python analisada está no arquivo [`download_receitanetbx.py`](./download_receitanetbx.py).

--- a/download_receitanetbx.py
+++ b/download_receitanetbx.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Diagnóstico Receitanet BX — foco em erro 5002.
+
+Objetivo:
+- Executar testes reproduzíveis contra o servidor para descobrir qual combinação
+  semântica de payload (idSistema/idPapel/campos) evita o erro 5002.
+- Gerar trilha de auditoria (JSONL/CSV) com request/response por tentativa.
+
+Este script NÃO tenta automatizar todo o fluxo de download. Ele é um utilitário
+para investigação precisa de erro de negócio.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import itertools
+import json
+import logging
+import re
+import socket
+import ssl
+import tempfile
+import time
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+# Dependência opcional para extrair cert/key de PFX (mTLS).
+try:
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+        pkcs12,
+    )
+except Exception:  # pragma: no cover
+    pkcs12 = None
+
+HOST_DEFAULT = "recnetsped.receita.fazenda.gov.br"
+PORT_DEFAULT = 3443
+
+
+@dataclass
+class ProbeResult:
+    idx: int
+    id_sistema: str
+    id_papel: str
+    campo_inicio: str
+    data_inicio: str
+    data_fim: str
+    status: str
+    codigo_detectado: str
+    mensagem_detectada: str
+    resposta_preview: str
+
+
+class FrameCodec:
+    """Codec do framing proprietário: [4-byte header] + [zlib payload]."""
+
+    @staticmethod
+    def encode(
+        text: str,
+        version: int = 0x01,
+        reserved: int = 0x00,
+        payload_encoding: str = "iso-8859-1",
+        length_endian: str = "little",
+    ) -> bytes:
+        raw = text.encode(payload_encoding)
+        comp = zlib.compress(raw)
+        header = bytes(
+            [version]
+        ) + len(raw).to_bytes(2, byteorder=length_endian, signed=False) + bytes([reserved])
+        return header + comp
+
+    @staticmethod
+    def decode(
+        packet: bytes,
+        payload_encoding: str = "iso-8859-1",
+        length_endian: str = "little",
+    ) -> Tuple[Dict[str, int], str]:
+        if len(packet) < 5:
+            raise ValueError("Pacote curto demais para framing.")
+        version = packet[0]
+        expected_len = int.from_bytes(packet[1:3], byteorder=length_endian, signed=False)
+        reserved = packet[3]
+        payload = packet[4:]
+        raw = zlib.decompress(payload)
+        text = raw.decode(payload_encoding, errors="replace")
+        return {
+            "version": version,
+            "expected_len": expected_len,
+            "actual_len": len(raw),
+            "reserved": reserved,
+        }, text
+
+
+class MTLSContextFactory:
+    @staticmethod
+    def from_pfx(pfx_path: str, password: str) -> ssl.SSLContext:
+        if pkcs12 is None:
+            raise RuntimeError("cryptography não disponível. Instale: pip install cryptography")
+
+        data = Path(pfx_path).read_bytes()
+        key, cert, _ = pkcs12.load_key_and_certificates(
+            data, password.encode("utf-8") if password else None
+        )
+        if key is None or cert is None:
+            raise RuntimeError("PFX inválido ou sem chave/certificado.")
+
+        key_pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+        cert_pem = cert.public_bytes(Encoding.PEM)
+
+        key_file = tempfile.NamedTemporaryFile(delete=False, suffix=".key")
+        cert_file = tempfile.NamedTemporaryFile(delete=False, suffix=".crt")
+        key_file.write(key_pem)
+        cert_file.write(cert_pem)
+        key_file.close()
+        cert_file.close()
+
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        if hasattr(ssl, "TLSVersion"):
+            ctx.minimum_version = ssl.TLSVersion.TLSv1
+            ctx.maximum_version = ssl.TLSVersion.TLSv1_2
+        ctx.load_cert_chain(certfile=cert_file.name, keyfile=key_file.name)
+        return ctx
+
+
+class ReceitanetProbeClient:
+    def __init__(self, host: str, port: int, timeout: int, ssl_ctx: ssl.SSLContext):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.ssl_ctx = ssl_ctx
+
+    def round_trip(self, packet: bytes) -> bytes:
+        with socket.create_connection((self.host, self.port), timeout=self.timeout) as sock:
+            with self.ssl_ctx.wrap_socket(sock, server_hostname=self.host) as ssock:
+                ssock.sendall(packet)
+                chunks: List[bytes] = []
+                ssock.settimeout(self.timeout)
+                while True:
+                    try:
+                        chunk = ssock.recv(8192)
+                    except socket.timeout:
+                        break
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+        return b"".join(chunks)
+
+
+def build_properties_payload(
+    id_sistema: str,
+    id_papel: str,
+    campo_inicio: str,
+    data_inicio: str,
+    data_fim: str,
+    perfil: str = "contribuinte",
+) -> str:
+    kv = [
+        ("idSistema", id_sistema),
+        ("idPapel", id_papel),
+        ("perfil", perfil),
+        ("id", "periodoEntrega"),
+        (campo_inicio, data_inicio),
+        ("dataFim", data_fim),
+    ]
+    return "\n".join(f"{k}={v}" for k, v in kv)
+
+
+def detect_business_error(text: str) -> Tuple[str, str]:
+    code_patterns = [r"\b(5002)\b", r"codigo\s*[=:]\s*(\d{4,})", r"<codigo>(\d+)</codigo>"]
+    for pat in code_patterns:
+        m = re.search(pat, text, flags=re.IGNORECASE)
+        if m:
+            code = m.group(1)
+            line = next((ln.strip() for ln in text.splitlines() if code in ln), "")
+            return code, line[:240]
+
+    msg = ""
+    for pat in [r"erro[^\n]{0,120}", r"mensagem[^\n]{0,160}"]:
+        m = re.search(pat, text, flags=re.IGNORECASE)
+        if m:
+            msg = m.group(0)
+            break
+    return "", msg[:240]
+
+
+def run_semantic_matrix(
+    client: ReceitanetProbeClient,
+    out_jsonl: Path,
+    out_csv: Path,
+    id_sistemas: Iterable[str],
+    id_papeis: Iterable[str],
+    campos_inicio: Iterable[str],
+    data_inicio: str,
+    data_fim: str,
+    pause_ms: int,
+) -> List[ProbeResult]:
+    out_jsonl.parent.mkdir(parents=True, exist_ok=True)
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+
+    results: List[ProbeResult] = []
+    idx = 0
+
+    with out_jsonl.open("w", encoding="utf-8") as jfp:
+        for id_sistema, id_papel, campo_inicio in itertools.product(id_sistemas, id_papeis, campos_inicio):
+            idx += 1
+            payload = build_properties_payload(
+                id_sistema=id_sistema,
+                id_papel=id_papel,
+                campo_inicio=campo_inicio,
+                data_inicio=data_inicio,
+                data_fim=data_fim,
+            )
+            packet = FrameCodec.encode(payload)
+
+            status = "ok"
+            detected_code = ""
+            detected_msg = ""
+            preview = ""
+
+            try:
+                response_packet = client.round_trip(packet)
+                if not response_packet:
+                    status = "sem_resposta"
+                else:
+                    try:
+                        _, response_text = FrameCodec.decode(response_packet)
+                        detected_code, detected_msg = detect_business_error(response_text)
+                        preview = response_text[:240].replace("\n", " ")
+                    except Exception as dec_err:
+                        status = f"decode_error:{type(dec_err).__name__}"
+                        preview = response_packet[:120].hex()
+            except Exception as net_err:
+                status = f"network_error:{type(net_err).__name__}"
+                preview = str(net_err)[:240]
+
+            pr = ProbeResult(
+                idx=idx,
+                id_sistema=id_sistema,
+                id_papel=id_papel,
+                campo_inicio=campo_inicio,
+                data_inicio=data_inicio,
+                data_fim=data_fim,
+                status=status,
+                codigo_detectado=detected_code,
+                mensagem_detectada=detected_msg,
+                resposta_preview=preview,
+            )
+            results.append(pr)
+
+            jfp.write(
+                json.dumps(
+                    {
+                        "idx": pr.idx,
+                        "idSistema": pr.id_sistema,
+                        "idPapel": pr.id_papel,
+                        "campoInicio": pr.campo_inicio,
+                        "dataInicio": pr.data_inicio,
+                        "dataFim": pr.data_fim,
+                        "status": pr.status,
+                        "codigoDetectado": pr.codigo_detectado,
+                        "mensagemDetectada": pr.mensagem_detectada,
+                        "respostaPreview": pr.resposta_preview,
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+
+            time.sleep(max(0, pause_ms) / 1000)
+
+    with out_csv.open("w", newline="", encoding="utf-8") as cfp:
+        writer = csv.writer(cfp)
+        writer.writerow(
+            [
+                "idx",
+                "idSistema",
+                "idPapel",
+                "campoInicio",
+                "dataInicio",
+                "dataFim",
+                "status",
+                "codigoDetectado",
+                "mensagemDetectada",
+                "respostaPreview",
+            ]
+        )
+        for r in results:
+            writer.writerow(
+                [
+                    r.idx,
+                    r.id_sistema,
+                    r.id_papel,
+                    r.campo_inicio,
+                    r.data_inicio,
+                    r.data_fim,
+                    r.status,
+                    r.codigo_detectado,
+                    r.mensagem_detectada,
+                    r.resposta_preview,
+                ]
+            )
+
+    return results
+
+
+def run_self_test() -> None:
+    payload = "id=periodoEntrega\ndataInicio=01/01/2025\ndataFim=31/01/2025"
+    packet = FrameCodec.encode(payload)
+    header, decoded = FrameCodec.decode(packet)
+
+    assert decoded == payload, "Decode diferente do payload original"
+    assert header["actual_len"] == len(payload.encode("iso-8859-1")), "Tamanho real inválido"
+
+    code, msg = detect_business_error("5002 - Erro no processamento da solicitação")
+    assert code == "5002", "Não detectou código 5002"
+    assert "5002" in msg, "Mensagem detectada sem código"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Diagnóstico semântico do Receitanet BX (erro 5002)")
+    p.add_argument("--host", default=HOST_DEFAULT)
+    p.add_argument("--port", type=int, default=PORT_DEFAULT)
+    p.add_argument("--timeout", type=int, default=20)
+
+    p.add_argument("--pfx", default="", help="Caminho do certificado PFX")
+    p.add_argument("--senha", default="", help="Senha do PFX")
+
+    p.add_argument("--id-sistemas", default="100,0", help="Lista CSV de idSistema")
+    p.add_argument("--id-papeis", default="1,2", help="Lista CSV de idPapel")
+    p.add_argument("--campos-inicio", default="dataInicio,dataIniion", help="Lista CSV de nomes de campo")
+
+    p.add_argument("--data-inicio", default="01/01/2025")
+    p.add_argument("--data-fim", default="31/01/2025")
+    p.add_argument("--pause-ms", type=int, default=400)
+
+    p.add_argument("--out-jsonl", default="diagnostico_receitanet/resultados.jsonl")
+    p.add_argument("--out-csv", default="diagnostico_receitanet/resultados.csv")
+    p.add_argument("--self-test", action="store_true", help="Executa testes locais sem rede")
+    p.add_argument("--debug", action="store_true")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    if args.self_test:
+        run_self_test()
+        print("Self-test OK.")
+        return 0
+
+    if not args.pfx:
+        raise SystemExit("Informe --pfx para testes reais com mTLS.")
+
+    ssl_ctx = MTLSContextFactory.from_pfx(args.pfx, args.senha)
+    client = ReceitanetProbeClient(args.host, args.port, args.timeout, ssl_ctx)
+
+    id_sistemas = [x.strip() for x in args.id_sistemas.split(",") if x.strip()]
+    id_papeis = [x.strip() for x in args.id_papeis.split(",") if x.strip()]
+    campos_inicio = [x.strip() for x in args.campos_inicio.split(",") if x.strip()]
+
+    results = run_semantic_matrix(
+        client=client,
+        out_jsonl=Path(args.out_jsonl),
+        out_csv=Path(args.out_csv),
+        id_sistemas=id_sistemas,
+        id_papeis=id_papeis,
+        campos_inicio=campos_inicio,
+        data_inicio=args.data_inicio,
+        data_fim=args.data_fim,
+        pause_ms=args.pause_ms,
+    )
+
+    total = len(results)
+    err5002 = sum(1 for r in results if r.codigo_detectado == "5002")
+    sucesso_sem_5002 = [r for r in results if r.status == "ok" and r.codigo_detectado != "5002"]
+
+    print(f"Tentativas: {total}")
+    print(f"Com código 5002: {err5002}")
+    print(f"Candidatas sem 5002: {len(sucesso_sem_5002)}")
+
+    if sucesso_sem_5002:
+        print("\nTop 5 candidatas:")
+        for r in sucesso_sem_5002[:5]:
+            print(
+                f"  idx={r.idx} idSistema={r.id_sistema} idPapel={r.id_papel} "
+                f"campoInicio={r.campo_inicio} status={r.status} codigo={r.codigo_detectado or '-'}"
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/download_receitanetbx.py
+++ b/download_receitanetbx.py
@@ -5,11 +5,8 @@ Diagnóstico Receitanet BX — foco em erro 5002.
 
 Objetivo:
 - Executar testes reproduzíveis contra o servidor para descobrir qual combinação
-  semântica de payload (idSistema/idPapel/campos) evita o erro 5002.
-- Gerar trilha de auditoria (JSONL/CSV) com request/response por tentativa.
-
-Este script NÃO tenta automatizar todo o fluxo de download. Ele é um utilitário
-para investigação precisa de erro de negócio.
+  semântica/protocolo evita o erro 5002.
+- Gerar trilha de auditoria (JSONL/CSV) com telemetria por tentativa.
 """
 
 from __future__ import annotations
@@ -18,7 +15,6 @@ import argparse
 import csv
 import itertools
 import json
-import logging
 import re
 import socket
 import ssl
@@ -27,7 +23,7 @@ import time
 import zlib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Tuple
 
 # Dependência opcional para extrair cert/key de PFX (mTLS).
 try:
@@ -52,9 +48,17 @@ class ProbeResult:
     campo_inicio: str
     data_inicio: str
     data_fim: str
+    transport_mode: str
+    length_endian: str
+    version: int
+    reserved: int
+    sni: str
+    greeting_hex: str
     status: str
     codigo_detectado: str
     mensagem_detectada: str
+    rtt_ms: int
+    bytes_recebidos: int
     resposta_preview: str
 
 
@@ -68,13 +72,16 @@ class FrameCodec:
         reserved: int = 0x00,
         payload_encoding: str = "iso-8859-1",
         length_endian: str = "little",
+        zlib_level: int = 6,
+        append_newline: bool = False,
     ) -> bytes:
         raw = text.encode(payload_encoding)
-        comp = zlib.compress(raw)
-        header = bytes(
-            [version]
-        ) + len(raw).to_bytes(2, byteorder=length_endian, signed=False) + bytes([reserved])
-        return header + comp
+        comp = zlib.compress(raw, level=zlib_level)
+        header = bytes([version]) + len(raw).to_bytes(2, byteorder=length_endian, signed=False) + bytes([reserved])
+        packet = header + comp
+        if append_newline:
+            packet += b"\n"
+        return packet
 
     @staticmethod
     def decode(
@@ -105,9 +112,7 @@ class MTLSContextFactory:
             raise RuntimeError("cryptography não disponível. Instale: pip install cryptography")
 
         data = Path(pfx_path).read_bytes()
-        key, cert, _ = pkcs12.load_key_and_certificates(
-            data, password.encode("utf-8") if password else None
-        )
+        key, cert, _ = pkcs12.load_key_and_certificates(data, password.encode("utf-8") if password else None)
         if key is None or cert is None:
             raise RuntimeError("PFX inválido ou sem chave/certificado.")
 
@@ -132,26 +137,61 @@ class MTLSContextFactory:
 
 
 class ReceitanetProbeClient:
+    """Cliente com modos de transporte para reduzir casos 'sem_resposta'."""
+
     def __init__(self, host: str, port: int, timeout: int, ssl_ctx: ssl.SSLContext):
         self.host = host
         self.port = port
         self.timeout = timeout
         self.ssl_ctx = ssl_ctx
 
-    def round_trip(self, packet: bytes) -> bytes:
+    def round_trip(
+        self,
+        packet: bytes,
+        transport_mode: str,
+        sni: str,
+        greeting: bytes,
+    ) -> Tuple[bytes, int]:
+        start = time.monotonic()
+        if transport_mode == "plain":
+            raw = self._round_trip_plain(packet, greeting)
+        elif transport_mode == "tls":
+            raw = self._round_trip_tls(packet, sni, greeting)
+        elif transport_mode == "tls-no-sni":
+            raw = self._round_trip_tls(packet, "", greeting)
+        else:
+            raise ValueError(f"transport_mode inválido: {transport_mode}")
+        rtt_ms = int((time.monotonic() - start) * 1000)
+        return raw, rtt_ms
+
+    def _round_trip_plain(self, packet: bytes, greeting: bytes) -> bytes:
         with socket.create_connection((self.host, self.port), timeout=self.timeout) as sock:
-            with self.ssl_ctx.wrap_socket(sock, server_hostname=self.host) as ssock:
+            sock.settimeout(self.timeout)
+            if greeting:
+                sock.sendall(greeting)
+            sock.sendall(packet)
+            return self._recv_all(sock)
+
+    def _round_trip_tls(self, packet: bytes, sni: str, greeting: bytes) -> bytes:
+        with socket.create_connection((self.host, self.port), timeout=self.timeout) as sock:
+            sock.settimeout(self.timeout)
+            sni_name = sni if sni else None
+            with self.ssl_ctx.wrap_socket(sock, server_hostname=sni_name) as ssock:
+                if greeting:
+                    ssock.sendall(greeting)
                 ssock.sendall(packet)
-                chunks: List[bytes] = []
-                ssock.settimeout(self.timeout)
-                while True:
-                    try:
-                        chunk = ssock.recv(8192)
-                    except socket.timeout:
-                        break
-                    if not chunk:
-                        break
-                    chunks.append(chunk)
+                return self._recv_all(ssock)
+
+    def _recv_all(self, conn: socket.socket) -> bytes:
+        chunks: List[bytes] = []
+        while True:
+            try:
+                chunk = conn.recv(8192)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
         return b"".join(chunks)
 
 
@@ -192,6 +232,52 @@ def detect_business_error(text: str) -> Tuple[str, str]:
     return "", msg[:240]
 
 
+def parse_csv_list(raw: str) -> List[str]:
+    return [x.strip() for x in raw.split(",") if x.strip()]
+
+
+def parse_int_list(raw: str) -> List[int]:
+    values: List[int] = []
+    for token in parse_csv_list(raw):
+        token = token.strip().lower()
+        values.append(int(token, 16) if token.startswith("0x") else int(token))
+    return values
+
+
+def parse_greeting(raw: str) -> bytes:
+    """
+    Aceita:
+      - vazio -> b''
+      - hex:001122AABB
+      - text:HELLO\r\n
+    """
+    raw = raw.strip()
+    if not raw:
+        return b""
+    if raw.startswith("hex:"):
+        return bytes.fromhex(raw[4:])
+    if raw.startswith("text:"):
+        return raw[5:].encode("latin-1", errors="replace")
+    return bytes.fromhex(raw)
+
+
+def decode_response_best_effort(packet: bytes) -> Tuple[str, str, str]:
+    """Retorna status_decode, texto_decodificado, preview."""
+    if not packet:
+        return "sem_resposta", "", ""
+
+    decode_errors: List[str] = []
+    for endian in ("little", "big"):
+        for encoding in ("iso-8859-1", "utf-8"):
+            try:
+                _, text = FrameCodec.decode(packet, payload_encoding=encoding, length_endian=endian)
+                return "ok", text, text[:240].replace("\n", " ")
+            except Exception as err:
+                decode_errors.append(f"{endian}/{encoding}:{type(err).__name__}")
+
+    return "decode_error", "", packet[:120].hex() + " | " + ",".join(decode_errors[:3])
+
+
 def run_semantic_matrix(
     client: ReceitanetProbeClient,
     out_jsonl: Path,
@@ -202,6 +288,13 @@ def run_semantic_matrix(
     data_inicio: str,
     data_fim: str,
     pause_ms: int,
+    transport_modes: Iterable[str],
+    length_endians: Iterable[str],
+    versions: Iterable[int],
+    reserved_values: Iterable[int],
+    sni_values: Iterable[str],
+    greeting: bytes,
+    append_newline: bool,
 ) -> List[ProbeResult]:
     out_jsonl.parent.mkdir(parents=True, exist_ok=True)
     out_csv.parent.mkdir(parents=True, exist_ok=True)
@@ -210,7 +303,18 @@ def run_semantic_matrix(
     idx = 0
 
     with out_jsonl.open("w", encoding="utf-8") as jfp:
-        for id_sistema, id_papel, campo_inicio in itertools.product(id_sistemas, id_papeis, campos_inicio):
+        product_iter = itertools.product(
+            id_sistemas,
+            id_papeis,
+            campos_inicio,
+            transport_modes,
+            length_endians,
+            versions,
+            reserved_values,
+            sni_values,
+        )
+
+        for id_sistema, id_papel, campo_inicio, transport_mode, length_endian, version, reserved, sni in product_iter:
             idx += 1
             payload = build_properties_payload(
                 id_sistema=id_sistema,
@@ -219,28 +323,39 @@ def run_semantic_matrix(
                 data_inicio=data_inicio,
                 data_fim=data_fim,
             )
-            packet = FrameCodec.encode(payload)
+            packet = FrameCodec.encode(
+                payload,
+                version=version,
+                reserved=reserved,
+                length_endian=length_endian,
+                append_newline=append_newline,
+            )
 
             status = "ok"
             detected_code = ""
             detected_msg = ""
             preview = ""
+            rtt_ms = 0
+            bytes_recv = 0
 
             try:
-                response_packet = client.round_trip(packet)
-                if not response_packet:
-                    status = "sem_resposta"
-                else:
-                    try:
-                        _, response_text = FrameCodec.decode(response_packet)
-                        detected_code, detected_msg = detect_business_error(response_text)
-                        preview = response_text[:240].replace("\n", " ")
-                    except Exception as dec_err:
-                        status = f"decode_error:{type(dec_err).__name__}"
-                        preview = response_packet[:120].hex()
-            except Exception as net_err:
-                status = f"network_error:{type(net_err).__name__}"
-                preview = str(net_err)[:240]
+                response_packet, rtt_ms = client.round_trip(
+                    packet=packet,
+                    transport_mode=transport_mode,
+                    sni=sni,
+                    greeting=greeting,
+                )
+                bytes_recv = len(response_packet)
+                decode_status, response_text, preview = decode_response_best_effort(response_packet)
+                status = decode_status
+                if decode_status == "ok":
+                    detected_code, detected_msg = detect_business_error(response_text)
+            except ssl.SSLError as err:
+                status = f"ssl_error:{err.__class__.__name__}"
+                preview = str(err)[:240]
+            except Exception as err:
+                status = f"network_error:{err.__class__.__name__}"
+                preview = str(err)[:240]
 
             pr = ProbeResult(
                 idx=idx,
@@ -249,32 +364,22 @@ def run_semantic_matrix(
                 campo_inicio=campo_inicio,
                 data_inicio=data_inicio,
                 data_fim=data_fim,
+                transport_mode=transport_mode,
+                length_endian=length_endian,
+                version=version,
+                reserved=reserved,
+                sni=sni,
+                greeting_hex=greeting.hex(),
                 status=status,
                 codigo_detectado=detected_code,
                 mensagem_detectada=detected_msg,
+                rtt_ms=rtt_ms,
+                bytes_recebidos=bytes_recv,
                 resposta_preview=preview,
             )
             results.append(pr)
 
-            jfp.write(
-                json.dumps(
-                    {
-                        "idx": pr.idx,
-                        "idSistema": pr.id_sistema,
-                        "idPapel": pr.id_papel,
-                        "campoInicio": pr.campo_inicio,
-                        "dataInicio": pr.data_inicio,
-                        "dataFim": pr.data_fim,
-                        "status": pr.status,
-                        "codigoDetectado": pr.codigo_detectado,
-                        "mensagemDetectada": pr.mensagem_detectada,
-                        "respostaPreview": pr.resposta_preview,
-                    },
-                    ensure_ascii=False,
-                )
-                + "\n"
-            )
-
+            jfp.write(json.dumps(pr.__dict__, ensure_ascii=False) + "\n")
             time.sleep(max(0, pause_ms) / 1000)
 
     with out_csv.open("w", newline="", encoding="utf-8") as cfp:
@@ -287,9 +392,17 @@ def run_semantic_matrix(
                 "campoInicio",
                 "dataInicio",
                 "dataFim",
+                "transportMode",
+                "lengthEndian",
+                "version",
+                "reserved",
+                "sni",
+                "greetingHex",
                 "status",
                 "codigoDetectado",
                 "mensagemDetectada",
+                "rttMs",
+                "bytesRecebidos",
                 "respostaPreview",
             ]
         )
@@ -302,9 +415,17 @@ def run_semantic_matrix(
                     r.campo_inicio,
                     r.data_inicio,
                     r.data_fim,
+                    r.transport_mode,
+                    r.length_endian,
+                    r.version,
+                    r.reserved,
+                    r.sni,
+                    r.greeting_hex,
                     r.status,
                     r.codigo_detectado,
                     r.mensagem_detectada,
+                    r.rtt_ms,
+                    r.bytes_recebidos,
                     r.resposta_preview,
                 ]
             )
@@ -314,19 +435,24 @@ def run_semantic_matrix(
 
 def run_self_test() -> None:
     payload = "id=periodoEntrega\ndataInicio=01/01/2025\ndataFim=31/01/2025"
-    packet = FrameCodec.encode(payload)
-    header, decoded = FrameCodec.decode(packet)
 
-    assert decoded == payload, "Decode diferente do payload original"
-    assert header["actual_len"] == len(payload.encode("iso-8859-1")), "Tamanho real inválido"
+    for endian in ("little", "big"):
+        packet = FrameCodec.encode(payload, length_endian=endian, version=0x02, reserved=0x00)
+        header, decoded = FrameCodec.decode(packet, length_endian=endian)
+        assert decoded == payload, f"Decode diferente do payload ({endian})"
+        assert header["actual_len"] == len(payload.encode("iso-8859-1")), "Tamanho real inválido"
 
     code, msg = detect_business_error("5002 - Erro no processamento da solicitação")
     assert code == "5002", "Não detectou código 5002"
     assert "5002" in msg, "Mensagem detectada sem código"
 
+    assert parse_greeting("") == b""
+    assert parse_greeting("hex:4142") == b"AB"
+    assert parse_greeting("text:AB") == b"AB"
+
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Diagnóstico semântico do Receitanet BX (erro 5002)")
+    p = argparse.ArgumentParser(description="Diagnóstico semântico/protocolo do Receitanet BX (erro 5002)")
     p.add_argument("--host", default=HOST_DEFAULT)
     p.add_argument("--port", type=int, default=PORT_DEFAULT)
     p.add_argument("--timeout", type=int, default=20)
@@ -338,23 +464,26 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--id-papeis", default="1,2", help="Lista CSV de idPapel")
     p.add_argument("--campos-inicio", default="dataInicio,dataIniion", help="Lista CSV de nomes de campo")
 
+    p.add_argument("--transport-modes", default="tls,tls-no-sni,plain", help="CSV: tls,tls-no-sni,plain")
+    p.add_argument("--length-endians", default="little,big", help="CSV: little,big")
+    p.add_argument("--versions", default="1,2", help="CSV de versões do byte 0 do header")
+    p.add_argument("--reserved-values", default="0", help="CSV de valores do byte reservado")
+    p.add_argument("--sni-values", default=f"{HOST_DEFAULT},", help="CSV de SNI; vazio permitido")
+    p.add_argument("--greeting", default="", help="prefixo opcional: hex:... ou text:...")
+    p.add_argument("--append-newline", action="store_true", help="Adiciona \\n ao fim do pacote")
+
     p.add_argument("--data-inicio", default="01/01/2025")
     p.add_argument("--data-fim", default="31/01/2025")
-    p.add_argument("--pause-ms", type=int, default=400)
+    p.add_argument("--pause-ms", type=int, default=300)
 
     p.add_argument("--out-jsonl", default="diagnostico_receitanet/resultados.jsonl")
     p.add_argument("--out-csv", default="diagnostico_receitanet/resultados.csv")
     p.add_argument("--self-test", action="store_true", help="Executa testes locais sem rede")
-    p.add_argument("--debug", action="store_true")
     return p.parse_args()
 
 
 def main() -> int:
     args = parse_args()
-    logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO,
-        format="%(asctime)s [%(levelname)s] %(message)s",
-    )
 
     if args.self_test:
         run_self_test()
@@ -367,9 +496,15 @@ def main() -> int:
     ssl_ctx = MTLSContextFactory.from_pfx(args.pfx, args.senha)
     client = ReceitanetProbeClient(args.host, args.port, args.timeout, ssl_ctx)
 
-    id_sistemas = [x.strip() for x in args.id_sistemas.split(",") if x.strip()]
-    id_papeis = [x.strip() for x in args.id_papeis.split(",") if x.strip()]
-    campos_inicio = [x.strip() for x in args.campos_inicio.split(",") if x.strip()]
+    id_sistemas = parse_csv_list(args.id_sistemas)
+    id_papeis = parse_csv_list(args.id_papeis)
+    campos_inicio = parse_csv_list(args.campos_inicio)
+    transport_modes = parse_csv_list(args.transport_modes)
+    length_endians = parse_csv_list(args.length_endians)
+    versions = parse_int_list(args.versions)
+    reserved_values = parse_int_list(args.reserved_values)
+    sni_values = [s for s in args.sni_values.split(",")]
+    greeting = parse_greeting(args.greeting)
 
     results = run_semantic_matrix(
         client=client,
@@ -381,22 +516,32 @@ def main() -> int:
         data_inicio=args.data_inicio,
         data_fim=args.data_fim,
         pause_ms=args.pause_ms,
+        transport_modes=transport_modes,
+        length_endians=length_endians,
+        versions=versions,
+        reserved_values=reserved_values,
+        sni_values=sni_values,
+        greeting=greeting,
+        append_newline=args.append_newline,
     )
 
     total = len(results)
+    sem_resposta = sum(1 for r in results if r.status == "sem_resposta")
     err5002 = sum(1 for r in results if r.codigo_detectado == "5002")
-    sucesso_sem_5002 = [r for r in results if r.status == "ok" and r.codigo_detectado != "5002"]
+    candidatas = [r for r in results if r.status == "ok" and r.codigo_detectado != "5002"]
 
     print(f"Tentativas: {total}")
+    print(f"Sem resposta: {sem_resposta}")
     print(f"Com código 5002: {err5002}")
-    print(f"Candidatas sem 5002: {len(sucesso_sem_5002)}")
+    print(f"Candidatas sem 5002: {len(candidatas)}")
 
-    if sucesso_sem_5002:
-        print("\nTop 5 candidatas:")
-        for r in sucesso_sem_5002[:5]:
+    if candidatas:
+        print("\nTop 10 candidatas:")
+        for r in candidatas[:10]:
             print(
-                f"  idx={r.idx} idSistema={r.id_sistema} idPapel={r.id_papel} "
-                f"campoInicio={r.campo_inicio} status={r.status} codigo={r.codigo_detectado or '-'}"
+                f"idx={r.idx} idSistema={r.id_sistema} idPapel={r.id_papel} "
+                f"modo={r.transport_mode} endian={r.length_endian} v={r.version} "
+                f"status={r.status} codigo={r.codigo_detectado or '-'} bytes={r.bytes_recebidos} rtt={r.rtt_ms}ms"
             )
 
     return 0


### PR DESCRIPTION
### Motivation
- Provide a reproducible diagnostic utility and documentation to investigate the persistent business error `5002` observed when integrating with the proprietary Receitanet BX protocol.
- Capture reverse-engineered protocol details and investigation notes to avoid repeating failed approaches and to guide future integration attempts.
- Give users a clear, runnable workflow for both local codec validation and controlled network probes using mTLS.

### Description
- Add `download_receitanetbx.py` which implements a proprietary framing `FrameCodec` (4-byte header + zlib payload), `MTLSContextFactory` for extracting cert/key from PFX, `ReceitanetProbeClient` to perform TLS round-trips, payload builder, business-error detector, and `run_semantic_matrix` to enumerate combinations and emit JSONL/CSV results.
- Add `RELATORIO_TECNICO_RECEITANET_BX.md` containing the reverse-engineered protocol details, sample payloads, and an analysis of the root causes and diagnostics for error `5002`.
- Update `README.md` with a content summary, usage examples for both the local self-test (`--self-test`) and real mTLS scans (example `--pfx` usage), and the expected output artifacts (`.jsonl` and `.csv`).
- Provide a safe self-test mode that validates `FrameCodec.encode`/`decode` and `detect_business_error` behavior without network access.

### Testing
- Executed the bundled self-test with `python download_receitanetbx.py --self-test`, which runs `run_self_test` assertions and completed successfully. 
- The `FrameCodec` encode/decode and the `detect_business_error` checks asserted expected behaviour during the self-test and passed. 
- No automated network probes were run because real scans require a client certificate (`--pfx`), so network matrix execution was not performed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b187f9e478833291ca8c06d1ea2a7c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new network-active tooling that handles client certificates and opens connections to an external endpoint; mistakes in TLS/cert handling or misuse could leak operational details, though changes are isolated to a standalone script and docs.
> 
> **Overview**
> Adds a new `download_receitanetbx.py` CLI that can locally self-test the proprietary framing codec and run mTLS-backed probe matrices (varying `idSistema`/`idPapel`, header fields, endianness, SNI, and transport mode) while emitting per-attempt JSONL/CSV logs and surfacing detected business errors like `5002`.
> 
> Includes a new technical report `RELATORIO_TECNICO_RECEITANET_BX.md` documenting the reverse-engineered framing/TLS assumptions and investigation findings, and updates `README.md` with concrete run recipes and expected output artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3d2bc09334f74f7f525b88ec5588a30bee8f725. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->